### PR TITLE
Add python2 support to platformsh installs for #11

### DIFF
--- a/web-build/Dockerfile.platformsh
+++ b/web-build/Dockerfile.platformsh
@@ -3,4 +3,4 @@ RUN ln -sf /var/www/html /app
 RUN echo "deb-src http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y build-dep python2 python3
 # python2-pip is no longer available for Debian bullseye
-RUN wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && python get-pip.py
+RUN wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && python2 get-pip.py

--- a/web-build/Dockerfile.platformsh
+++ b/web-build/Dockerfile.platformsh
@@ -1,2 +1,6 @@
 #ddev-generated
 RUN ln -sf /var/www/html /app
+RUN echo "deb-src http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get -y build-dep python2 python3
+# python2-pip is no longer available for Debian bullseye
+RUN wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && python get-pip.py


### PR DESCRIPTION
It seems that python2 is installed as platform in most platform VMs, so add that. Even when not explicitly used, it may be used in things like `yarn install`