### PR TITLE
Use a lightweight docker image to replace fragile jq, shasum, etc, fixes #100, for #46, fixes #96, fixes #93

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Make sure you have [DDEV v1.21.6+ installed](https://ddev.readthedocs.io/en/late
 
 ### Upgrade
 
-To upgrade your version of ddev-platformsh, just repeat the `ddev get ddev/ddev-platformsh` to get the latest release.
+To upgrade your version of ddev-platformsh, repeat the `ddev get ddev/ddev-platformsh` to get the latest release.
+
+### Run it again if you change your Platform.sh configuration
+
+If you change your `.platform.app.yaml` or something in your `.platform` directory, repeat the `ddev get ddev/ddev-platformsh` so that the generated configuration for DDEV will be updated.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,8 @@ This repository is used with `ddev get ddev/ddev-platformsh` to get a rich integ
 
 ## Using with a Platform.sh project
 ### Dependencies
-1. Make sure you have [DDEV v1.21.1+ installed](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/)
-2. The following tools need to be installed for the add-on to run smoothly (you may get them using your regular package manager):
-   * `jq`
-   * `base64`
-   * `perl`
+
+Make sure you have [DDEV v1.21.6+ installed](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/)
 
 ### Install
 1. Clone your project repository (e.g. `platform get <projectid>`)
@@ -20,6 +17,10 @@ This repository is used with `ddev get ddev/ddev-platformsh` to get a rich integ
 5. Run `ddev start`
 6. (Optional) Run `ddev pull platform` to retrieve a copy of the database and contents from the project's file mounts from the environment you entered in step #5
    1. If you only want to retrieve the database (skipping the file mounts), add the `--skip-files` flag to the `ddev pull platform` command
+
+### Upgrade
+
+To upgrade your version of ddev-platformsh, just repeat the `ddev get ddev/ddev-platformsh` to get the latest release.
 
 ## Notes
 

--- a/install.yaml
+++ b/install.yaml
@@ -115,10 +115,10 @@ post_install_actions:
   #ddev-nodisplay
   cd ..
   unset DDEV_DEBUG
-  project_type=$(ddev describe -j | docker run --rm ddev/ddev-utilities jq -r .raw.type)
+  project_type=$(ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r .raw.type)
   case $project_type in 
     laravel)
-      docker run --rm ddev/ddev-utilities perl -p -e 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' -e -e "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" <.env.example >.env
+      docker run -i --rm ddev/ddev-utilities perl -p -e 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' -e -e "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" <.env.example >.env
       ;;
     drupal9)
       mkdir -p .drush
@@ -152,10 +152,10 @@ post_install_actions:
   }
   ENDROUTES
   )
-  BASE64_ENCODE="docker run --rm ddev/ddev-utilities base64 -w 0"
-  BASE64_DECODE="docker run --rm ddev/ddev-utilities base64 -d"
+  BASE64_ENCODE="docker run -i --rm ddev/ddev-utilities base64 -w 0"
+  BASE64_DECODE="docker run -i --rm ddev/ddev-utilities base64 -d"
   PLATFORM_ROUTES="$(echo -n ${platform_routes} | ${BASE64_ENCODE})"
-  PLATFORM_PROJECT_ENTROPY="$(echo $RANDOM | docker run --rm ddev/ddev-utilities shasum -a 256 | awk '{print $1}')"
+  PLATFORM_PROJECT_ENTROPY="$(echo $RANDOM | docker run -i --rm ddev/ddev-utilities shasum -a 256 | awk '{print $1}')"
   
   {{/* Handling services relationships */}}
   export relationships=()
@@ -184,7 +184,7 @@ post_install_actions:
       # echo dbtype={{ $dbtype }}
       {{ if $dbtype }}
         # Unfortunate sed to remove color escape sequences from ddev debug output
-        current_db_version="$(ddev debug get-volume-db-version | sed -r 's/\x1b\[[0-9;]*m?//g')"
+        current_db_version="$(ddev debug get-volume-db-version | docker run -i --rm ddev/ddev-utilities sed -r 's/\x1b\[[0-9;]*m?//g')"
         export DBTYPE={{ regexReplaceAll ":.*$" $dbtype "" }}
         export DBVERSION={{ regexReplaceAll "^.*:" $dbtype "" }}
         if [ "${current_db_version}" != "" ] && [ ">{{ $dbtype }}<" != ">${current_db_version}<" ]; then

--- a/install.yaml
+++ b/install.yaml
@@ -21,17 +21,8 @@ pre_install_actions:
 
   - |
     #ddev-nodisplay
-    #ddev-description:Check for required tools base64, jq, perl
-    needed=""
-    for item in base64 jq perl ; do
-      if ! command -v $item >/dev/null; then
-        needed="${needed} ${item}"
-      fi
-    done
-    if [ "${needed}" != "" ]; then
-      echo "Please install ${needed} on the host computer to use this add-on.";
-      exit 1;
-    fi
+    #ddev-description:pull ddev/ddev-utilities
+    docker pull ddev/ddev-utilities
 
   # Get PLATFORMSH_CLI_TOKEN from user if we don't have it yet
   - |
@@ -124,13 +115,10 @@ post_install_actions:
   #ddev-nodisplay
   cd ..
   unset DDEV_DEBUG
-  project_type=$(ddev describe -j | jq -r .raw.type)
+  project_type=$(ddev describe -j | docker run --rm ddev/ddev-utilities jq -r .raw.type)
   case $project_type in 
     laravel)
-      # TODO: This depends on perl, but we can't start the project unless these are created
-      # so can't use ddev exec yet. 
-      perl -p -e 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' .env.example >.env
-      perl -pi.bak -e "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" .env
+      docker run --rm ddev/ddev-utilities perl -p -e 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' -e -e "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" <.env.example >.env
       ;;
     drupal9)
       mkdir -p .drush
@@ -164,11 +152,10 @@ post_install_actions:
   }
   ENDROUTES
   )
-  BASE64_ENCODE="base64"
-  if base64 -w 0 </dev/null >/dev/null 2>&1; then BASE64_ENCODE="base64 -w 0"; fi
-  echo BASE64_ENCODE=${BASE64_ENCODE}
+  BASE64_ENCODE="docker run --rm ddev/ddev-utilities base64 -w 0"
+  BASE64_DECODE="docker run --rm ddev/ddev-utilities base64 -d"
   PLATFORM_ROUTES="$(echo -n ${platform_routes} | ${BASE64_ENCODE})"
-  PLATFORM_PROJECT_ENTROPY="$(echo $RANDOM | shasum -a 256 | awk '{print $1}')"
+  PLATFORM_PROJECT_ENTROPY="$(echo $RANDOM | docker run --rm ddev/ddev-utilities shasum -a 256 | awk '{print $1}')"
   
   {{/* Handling services relationships */}}
   export relationships=()
@@ -206,7 +193,7 @@ post_install_actions:
         fi
         # echo ./platformsh/generate_db_relationship.sh '{{ $relationship_name }}' '{{ $dbtype }}' '{{ $relationship_name }}' 
         relationships+=($(./platformsh/generate_db_relationship.sh '{{ $relationship_name }}' '{{ $dbtype }}' '{{ $relationship_name }}' | ${BASE64_ENCODE}))
-        #printf "relationships length after db=${#relationships[@]}\nrelationships value=$(echo $relationships | base64 -d)"
+        #printf "relationships length after db=${#relationships[@]}\nrelationships value=$(echo $relationships | ${BASE64_DECODE})"
       {{ end }}
     {{ else if hasKey $supported_services $service_def.type }}
       {{/* Other services */}}
@@ -220,8 +207,8 @@ post_install_actions:
   {{ end }}
 
   #echo "Number of relationships=${#relationships[@]}"
-  PLATFORM_RELATIONSHIPS="$((echo '{'; for r in ${relationships[@]::${#relationships[@]}-1}; do echo $r | base64 -d; printf ', \n'; done; echo ${relationships[@]: -1:1} | base64 -d; echo ' }') | ${BASE64_ENCODE})"
-  #printf "PLATFORM_RELATIONSHIPS=$(echo $PLATFORM_RELATIONSHIPS | base64 -d)"
+  PLATFORM_RELATIONSHIPS="$((echo '{'; for r in ${relationships[@]::${#relationships[@]}-1}; do echo $r | ${BASE64_DECODE}; printf ', \n'; done; echo ${relationships[@]: -1:1} | ${BASE64_DECODE}; echo ' }') | ${BASE64_ENCODE})"
+  #printf "PLATFORM_RELATIONSHIPS=$(echo $PLATFORM_RELATIONSHIPS | ${BASE64_DECODE})"
   
   if [ -f config.platformsh.yaml ] && ! grep '#ddev-generated' config.platformsh.yaml; then
     echo "Existing config.platformsh.yaml does not have #ddev-generated, so can't be updated"

--- a/install.yaml
+++ b/install.yaml
@@ -118,7 +118,9 @@ post_install_actions:
   project_type=$(ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r .raw.type)
   case $project_type in 
     laravel)
-      docker run -i --rm ddev/ddev-utilities perl -p -e 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' -e -e "s#APP_URL=.*#APP_URL=${DDEV_PRIMARY_URL}#g" <.env.example >.env
+      #set -x
+      # The double-run here is awkward, but I didn't figure out how to do it with two '-e'
+      docker run -i --rm ddev/ddev-utilities perl -p -e "s!APP_URL=.*!APP_URL=${DDEV_PRIMARY_URL}!g" <.env.example | docker run -i --rm ddev/ddev-utilities perl -p -e 's!DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)!DB_\1=db!g'   >.env
       ;;
     drupal9)
       mkdir -p .drush


### PR DESCRIPTION
* #100
* #96
* #46
* #93

We've been very fragile with regard to requiring the user to install
* base64
* jq
* perl
* sed
* shasum

This switches to using a lightweight docker image to do those activities.