### PR TITLE
[tests only] keepalive workflow only runs on stable, prevent conflict

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,3 +87,4 @@ jobs:
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days
     - uses: gautamkrishnar/keepalive-workflow@v1
+      if: matrix.ddev_version == 'stable'


### PR DESCRIPTION
## The Issue

The keepalive workflow pushes a commit; if it runs on both workflows it breaks.


## How This PR Solves The Issue

Only run it on "stable"

