### PR TITLE
ci: maintenance on tests to use new github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,7 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # Allow `--HEAD` flag when running tests against HEAD
-  HOMEBREW_NO_INSTALL_FROM_API: 1
 
 jobs:
   tests:
@@ -36,59 +33,17 @@ jobs:
 
     strategy:
       matrix:
-#        ddev_version: [ HEAD ]
         ddev_version: [stable, HEAD]
-#        ddev_version: [PR]
       fail-fast: false
 
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-    - uses: actions/checkout@v3
-    - name: Environment setup
-      run: |
-        # For bats-assert and friends
-        brew tap kaos/shell
-        brew install bats-core bats-assert bats-support jq mkcert yq
-        mkcert -install
+      - uses: ddev/github-action-add-on-test@v1
+        with:
+          ddev_version: ${{ matrix.ddev_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          addon_repository: ${{ env.GITHUB_REPOSITORY }}
+          addon_ref: ${{ env.GITHUB_REF }}
 
-    - name: Use ddev stable
-      if: matrix.ddev_version == 'stable'
-      run: brew install ddev/ddev/ddev
-
-    - name: Use ddev edge
-      if: matrix.ddev_version == 'edge'
-      run: brew install ddev/ddev-edge/ddev
-
-    - name: Use ddev HEAD
-      if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD ddev/ddev/ddev
-
-    - name: Use ddev PR
-      if: matrix.ddev_version == 'PR'
-      run: |
-        curl -sSL -o ddev_linux.zip ${NIGHTLY_DDEV_PR_URL}
-        unzip ddev_linux.zip
-        mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
-
-    - name: Download docker images
-      run: | 
-        mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
-        docker pull memcached:1.6 >/dev/null
-    - name: tmate debugging session
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-
-    - name: tests
-      run: bats tests
-
-      # keepalive-workflow adds a dummy commit if there's no other action here, keeps
-      # GitHub from turning off tests after 60 days
-    - uses: gautamkrishnar/keepalive-workflow@v1
-      if: matrix.ddev_version == 'stable'

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is used with `ddev get ddev/ddev-platformsh` to get a rich integ
 ## Using with a Platform.sh project
 ### Dependencies
 
-Make sure you have [DDEV v1.21.6+ installed](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/)
+Make sure you have [DDEV v1.22.1+ installed](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/)
 
 ### Install
 1. Clone your project repository (e.g. `platform get <projectid>`)
@@ -20,7 +20,7 @@ Make sure you have [DDEV v1.21.6+ installed](https://ddev.readthedocs.io/en/late
 
 ### Upgrade
 
-To upgrade your version of ddev-platformsh, repeat the `ddev get ddev/ddev-platformsh` to get the latest release.
+To upgrade your version of ddev-platformsh, repeat the `ddev get ddev/ddev-platformsh` to get the latest release. To see the installed version, `ddev get --installed`.
 
 ### Run it again if you change your Platform.sh configuration
 
@@ -29,7 +29,7 @@ If you change your `.platform.app.yaml` or something in your `.platform` directo
 ## Notes
 
 * If your local project has a different database type than the upstream (Platform.sh) database, it will conflict, so please back up your database with `ddev export-db` and `ddev delete -y` before starting the project with new config based on upstream.
-* Your experience is super-important: Please let us know about how it went for you in any of the [DDEV support venues](https://ddev.readthedocs.io/en/latest/#support-and-user-contributed-documentation)
+* Your experience is super-important: Please let us know about how it went for you in any of the [DDEV support venues](https://ddev.readthedocs.io/en/latest/users/support/)
 
 ## What does it do right now?
 
@@ -37,7 +37,7 @@ If you change your `.platform.app.yaml` or something in your `.platform` directo
     * PHP and Database version
     * hooks are converted to DDEV post-start hooks
     * A working `ddev pull platform` integration with all mounts is created.
-    * Exposes specific `$PLATFORM_` variables (e.g., `$PLATFORM_RELATIONSHIPS`)
+    * Exposes specific `$PLATFORM_` variables (e.g., `$PLATFORM_RELATIONSHIPS`, `$PLATFORM_ROUTES`)
 * Supports the following services:
     * Databases
       * MariaDB
@@ -55,20 +55,21 @@ If you change your `.platform.app.yaml` or something in your `.platform` directo
   * PLATFORM_PROJECT
   * PLATFORM_PROJECT_ENTROPY
   * PLATFORM_RELATIONSHIPS
-  * PLATFORM_ROUTES (see note below)
+  * PLATFORM_ROUTES
   * PLATFORM_TREE_ID
   * PLATFORM_VARIABLES
-
-DDEV does not currently parse the contents of `.platform/routes.yaml` and therefore, `PLATFORM_ROUTES` only contains information related to a single, default route.
 
 ## What has been tested
 
 These Platform.sh templates are included in the automated tests that run nightly. They will be growing in maturity with your feedback!
 
 * [php](https://github.com/platformsh-templates/php)
-* [drupal9](https://github.com/platformsh-templates/drupal9) and [drupal8](https://github.com/platformsh-templates/drupal8)
+* [drupal9](https://github.com/platformsh-templates/drupal9) and [drupal10](https://github.com/platformsh-templates/drupal10)
 * [laravel](https://github.com/platformsh-templates/laravel)
+* [magento2ce](https://github.com/platformsh-templates/magento2ce)
 * [wordpress-composer](https://github.com/platformsh-templates/wordpress-composer)
+
+(Each of the above but magento2ce has automated tests.)
 
 ## What will it do in the future
 


### PR DESCRIPTION
## The Issue

* Much of the tests.yaml can now be removed in favor of https://github.com/ddev/github-action-add-on-test

