### PR TITLE
feat: support composer version when found in .platform.app.yaml

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -147,6 +147,16 @@ post_install_actions:
   BASE64_DECODE="docker run -i --rm ddev/ddev-utilities base64 -d"
   PLATFORM_PROJECT_ENTROPY="$(echo $RANDOM | docker run -i --rm ddev/ddev-utilities shasum -a 256 | awk '{print $1}')"
 
+  {{ $composerVersion := "2" }}
+  {{ with .platformapp.dependencies.php }}
+    {{ range $package, $version := . }}
+      {{ if eq $package "composer/composer" }}
+        {{ $composerVersion = replace "^" "" $version }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  
+
   routes=()
   #set -x
   #echo {{ .routes }}
@@ -231,6 +241,7 @@ post_install_actions:
   disable_settings_management: true
   {{ $phpversion := trimPrefix "php:" .platformapp.type }}
   php_version: {{ $phpversion }}
+  composer_version: "{{ $composerVersion }}"
   database:
     type: ${DBTYPE:-mariadb}
     version: ${DBVERSION:-10.4}

--- a/tests/composerversion.bats
+++ b/tests/composerversion.bats
@@ -1,0 +1,45 @@
+# Requires bats-assert and bats-support
+# brew tap kaos/shell &&
+# brew install bats-core bats-assert bats-support jq mkcert yq
+setup() {
+  load setup.sh
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
+}
+
+teardown() {
+  load teardown.sh
+}
+
+# mariadb is called mysql in platform.sh
+@test "composerversion" {
+  template="composerversion"
+  load per_test.sh
+  for source in "${PROJECT_SOURCE}"; do
+      rm -rf ${TESTDIR} && mkdir -p ${TESTDIR}
+      for t in $PROJECT_SOURCE/tests/testdata/${template}/*; do
+        cp -r $t/. ${TESTDIR}
+        pushd ${TESTDIR} >/dev/null
+        ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
+        echo "# doing ddev config --project-name=${PROJNAME}" >&3
+        ddev config --project-name=${PROJNAME} >/dev/null
+        echo "# doing ddev get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+        printf "x\nx\nx\n" | ddev get $source
+        ddev start -y >/dev/null
+        base=$(basename $t)
+        expectedComposerVersion=${base#*_}
+        echo "# base=${base} expectedComposerVersion=${expectedComposerVersion}" >&3
+        run ddev exec "composer --version | awk '{print \$3}'"
+
+        # If version has a caret, then we just want the first number
+        # Otherwise we use the explicit value provided
+        if [[ "$expectedComposerVersion" == "^"* ]]; then
+          expectedComposerVersion=${expectedComposerVersion:1:2}
+          assert_output --regexp "^${expectedComposerVersion}"
+        else
+          assert_output "$expectedComposerVersion"
+        fi
+      done
+    popd >/dev/null
+    per_test_teardown
+  done
+}

--- a/tests/testdata/composerversion/composer_2.5.6/.platform.app.yaml
+++ b/tests/testdata/composerversion/composer_2.5.6/.platform.app.yaml
@@ -1,0 +1,19 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/configuration/app.html
+
+# The name of this app. Must be unique within a project.
+name: 'drupal'
+
+# The runtime the application uses.
+type: 'php:8.0'
+
+dependencies:
+    php:
+        composer/composer: '2.5.6'
+
+# Configuration of the build of this application.
+build:
+    flavor: composer
+

--- a/tests/testdata/composerversion/composer_^1/.platform.app.yaml
+++ b/tests/testdata/composerversion/composer_^1/.platform.app.yaml
@@ -1,0 +1,19 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/configuration/app.html
+
+# The name of this app. Must be unique within a project.
+name: 'drupal'
+
+# The runtime the application uses.
+type: 'php:8.0'
+
+dependencies:
+    php:
+        composer/composer: '^1'
+
+# Configuration of the build of this application.
+build:
+    flavor: composer
+

--- a/tests/testdata/composerversion/composer_^2/.platform.app.yaml
+++ b/tests/testdata/composerversion/composer_^2/.platform.app.yaml
@@ -1,0 +1,19 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/configuration/app.html
+
+# The name of this app. Must be unique within a project.
+name: 'drupal'
+
+# The runtime the application uses.
+type: 'php:8.0'
+
+dependencies:
+    php:
+        composer/composer: '^2'
+
+# Configuration of the build of this application.
+build:
+    flavor: composer
+


### PR DESCRIPTION
## The Issue

We need to use the composer version found in .platform.app.yaml

## How This PR Solves The Issue

Attempts to parse the composer/composer php dependency if it exists, and translate it into ddev's format, `composer_version: "2"` for example.

## Manual Testing Instructions

This can be tested using
```
ddev get rfay/ddev-platformsh/tarball/20230829_composer_version
```

## Automated Testing Overview

Added composerversion test

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

