### PR TITLE
remove extraneous output from ddev head version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,11 @@ jobs:
       fail-fast: false
 
     runs-on: ubuntu-latest
-
+    env:
+      # Don't try interactive behaviors
+      DDEV_NONINTERACTIVE: "true"
+      # Don't send telemetry to amplitude
+      DDEV_NO_INSTRUMENTATION: "true"
     steps:
       - uses: ddev/github-action-add-on-test@v1
         with:

--- a/tests/composerversion.bats
+++ b/tests/composerversion.bats
@@ -28,7 +28,7 @@ teardown() {
         base=$(basename $t)
         expectedComposerVersion=${base#*_}
         echo "# base=${base} expectedComposerVersion=${expectedComposerVersion}" >&3
-        run ddev exec "composer --version | awk '{print \$3}'"
+        run ddev exec "composer --version | awk '{print \$3}'" 2>/dev/null
 
         # If version has a caret, then we just want the first number
         # Otherwise we use the explicit value provided

--- a/tests/drupal10.bats
+++ b/tests/drupal10.bats
@@ -15,26 +15,26 @@ teardown() {
   for source in $PROJECT_SOURCE ddev/ddev-platformsh; do
     per_test_setup
 
-    ddev exec drush cr
+    ddev exec drush cr 2>/dev/null
 
     run curl -L -s http://${PROJNAME}.ddev.site/
     assert_output --partial "Test of ddev-platformsh on drupal10"
 
-    run ddev exec -s db 'echo ${DDEV_DATABASE}'
+    run ddev exec -s db 'echo ${DDEV_DATABASE}' 2>/dev/null
     assert_output "mariadb:10.4"
-    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'"
+    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'" 2>/dev/null
     assert_output "8.1"
 
-    ddev exec 'touch ${PLATFORM_CACHE_DIR}/junk.txt'
+    ddev exec 'touch ${PLATFORM_CACHE_DIR}/junk.txt' 2>/dev/null
 
     ddev describe -j >describe.json
     run  jq -r .raw.docroot <describe.json
     assert_output "web"
 
-    assert_equal "$(ddev exec 'echo $PLATFORM_ROUTES | base64 -d | jq -r "keys[0]"')" "https://${PROJNAME}.ddev.site/"
-    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json
+    assert_equal "$(ddev exec 'echo $PLATFORM_ROUTES 2>/dev/null | base64 -d | jq -r "keys[0]"')" "https://${PROJNAME}.ddev.site/"
+    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json 2>/dev/null
     echo "# PLATFORM_RELATIONSHIPS=$(cat relationships.json)" >&3
-    ddev exec 'echo $PLATFORM_ROUTES | base64 -d' >routes.json
+    ddev exec 'echo $PLATFORM_ROUTES | base64 -d' >routes.json 2>/dev/null
     echo "# PLATFORM_ROUTES=$(cat routes.json)" >&3
 
     assert_equal "$(jq -r .database[0].type <relationships.json)" "mariadb:10.4"

--- a/tests/drupal9.bats
+++ b/tests/drupal9.bats
@@ -15,26 +15,26 @@ teardown() {
   for source in $PROJECT_SOURCE ddev/ddev-platformsh; do
     per_test_setup
 
-    ddev exec drush cr
+    ddev exec drush cr 2>/dev/null
 
     run curl -L -s http://${PROJNAME}.ddev.site/
     assert_output --partial "this is a test of ddev-platformsh drupal9"
 
-    run ddev exec -s db 'echo ${DDEV_DATABASE}'
+    run ddev exec -s db 'echo ${DDEV_DATABASE}' 2>/dev/null
     assert_output "mariadb:10.4"
-    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'"
+    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'" 2>/dev/null
     assert_output "8.1"
 
-    ddev exec 'touch ${PLATFORM_CACHE_DIR}/junk.txt'
+    ddev exec 'touch ${PLATFORM_CACHE_DIR}/junk.txt' 2>/dev/null
 
-    ddev describe -j >describe.json
+    ddev describe -j >describe.json 2>/dev/null
     run  jq -r .raw.docroot <describe.json
     assert_output "web"
 
-    assert_equal "$(ddev exec 'echo $PLATFORM_ROUTES | base64 -d | jq -r "keys[0]"')" "https://${PROJNAME}.ddev.site/"
-    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json
+    assert_equal "$(ddev exec 'echo $PLATFORM_ROUTES | base64 -d | jq -r "keys[0]"' 2>/dev/null)" "https://${PROJNAME}.ddev.site/"
+    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json 2>/dev/null
     echo "# PLATFORM_RELATIONSHIPS=$(cat relationships.json)" >&3
-    ddev exec 'echo $PLATFORM_ROUTES | base64 -d' >routes.json
+    ddev exec 'echo $PLATFORM_ROUTES | base64 -d' >routes.json 2>/dev/null
     echo "# PLATFORM_ROUTES=$(cat routes.json)" >&3
 
     assert_equal "$(jq -r .database[0].type <relationships.json)" "mariadb:10.4"

--- a/tests/laravel.bats
+++ b/tests/laravel.bats
@@ -16,9 +16,9 @@ teardown() {
   for source in $PROJECT_SOURCE ddev/ddev-platformsh; do
     per_test_setup
 
-    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'"
+    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'" 2>/dev/null
     assert_output "8.0"
-    ddev describe -j >describe.json
+    ddev describe -j >describe.json 2>/dev/null
     run  jq -r .raw.docroot <describe.json
     assert_output "public"
     docker inspect ddev-${PROJNAME}-redis >/dev/null

--- a/tests/mysql.bats
+++ b/tests/mysql.bats
@@ -25,9 +25,9 @@ teardown() {
     printf "x\nx\nx\n" | ddev get $source
     ddev start -y >/dev/null
     DDEV_DEBUG="" ddev describe -j >/tmp/describe.json
-    run ddev exec -s db 'echo ${DDEV_DATABASE}'
+    run ddev exec -s db 'echo ${DDEV_DATABASE}' >/dev/null
     assert_output "mariadb:10.5"
-    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json
+    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json 2>/dev/null
 
     echo "# PLATFORM_RELATIONSHIPS=$(cat relationships.json)" >&3
 

--- a/tests/oddrelationships.bats
+++ b/tests/oddrelationships.bats
@@ -24,7 +24,7 @@ teardown() {
     printf "x\nx\nx\n" | ddev get $source
     ddev start -y >/dev/null
     DDEV_DEBUG="" ddev describe -j >/tmp/describe.json
-    run ddev exec -s db 'echo ${DDEV_DATABASE}'
+    run ddev exec -s db 'echo ${DDEV_DATABASE}' >/dev/null
     assert_output "mysql:8.0"
     run jq -r .raw.services.redis.status </tmp/describe.json
     assert_output "running"
@@ -32,7 +32,7 @@ teardown() {
     assert_output "running"
     run jq -r .raw.services.memcached.status </tmp/describe.json
     assert_output "running"
-    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json
+    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json 2>/dev/null
 
     echo "# PLATFORM_RELATIONSHIPS=$(cat relationships.json)" >&3
 

--- a/tests/oracle-mysql.bats
+++ b/tests/oracle-mysql.bats
@@ -24,10 +24,10 @@ teardown() {
     printf "x\nx\nx\n" | ddev get $source
     ddev start -y >/dev/null
     DDEV_DEBUG="" ddev describe -j >/tmp/describe.json
-    run ddev exec -s db 'echo ${DDEV_DATABASE}'
+    run ddev exec -s db 'echo ${DDEV_DATABASE}' >/dev/null
     assert_output "mysql:8.0"
 
-    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json
+    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json 2>/dev/null
     echo "# PLATFORM_RELATIONSHIPS=$(cat relationships.json)" >&3
 
     assert_equal "$(jq -r .database[0].type <relationships.json)" "mysql:8.0"

--- a/tests/php.bats
+++ b/tests/php.bats
@@ -16,7 +16,7 @@ teardown() {
   for source in $PROJECT_SOURCE ddev/ddev-platformsh; do
     per_test_setup
 
-    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'"
+    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'" 2>/dev/null
     assert_output "8.0"
     ddev describe -j >describe.json
     run  jq -r .raw.docroot <describe.json

--- a/tests/postgresql.bats
+++ b/tests/postgresql.bats
@@ -24,12 +24,12 @@ teardown() {
     printf "x\nx\nx\n" | ddev get $source
     ddev start -y >/dev/null
     DDEV_DEBUG="" ddev describe -j >/tmp/describe.json
-    run ddev exec -s db 'echo ${DDEV_DATABASE}'
+    run ddev exec -s db 'echo ${DDEV_DATABASE}' >/dev/null
     assert_output "postgres:12"
 
     echo "# PLATFORM_RELATIONSHIPS=$(cat relationships.json)" >&3
 
-    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json
+    ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json 2>/dev/null
     assert_equal "$(jq -r .database[0].type <relationships.json)" "postgres:12"
     assert_equal "$(jq -r .database[0].username <relationships.json)" "db"
     assert_equal "$(jq -r .database[0].password <relationships.json)" "db"

--- a/tests/wordpress-bedrock.bats
+++ b/tests/wordpress-bedrock.bats
@@ -18,11 +18,11 @@ teardown() {
     run curl -s http://${PROJNAME}.ddev.site/phpinfo.php
     assert_line "DB_USER=db DB_PASSWORD=db"
     curl -s http://${PROJNAME}.ddev.site  | grep "Mindblown: a blog about"
-    run ddev exec -s db 'echo ${DDEV_DATABASE}'
+    run ddev exec -s db 'echo ${DDEV_DATABASE}' 2>/dev/null
     assert_output "mariadb:10.4"
-    run ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d | jq -r ".database[0].username"'
+    run ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d | jq -r ".database[0].username"' 2>/dev/null
     assert_output "db"
-    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'"
+    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'" 2>/dev/null
     assert_output "8.1"
     ddev describe -j >describe.json
     run  jq -r .raw.docroot <describe.json

--- a/tests/wordpress-composer.bats
+++ b/tests/wordpress-composer.bats
@@ -15,13 +15,13 @@ teardown() {
   for source in $PROJECT_SOURCE ddev/ddev-platformsh; do
     per_test_setup
 
-    run ddev exec -s db 'echo ${DDEV_DATABASE}'
+    run ddev exec -s db 'echo ${DDEV_DATABASE}' 2>/dev/null
     assert_output "mariadb:10.4"
-    run ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d | jq -r ".database[0].username"'
+    run ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d | jq -r ".database[0].username"' 2>/dev/null
     assert_output "db"
-    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'"
+    run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'" 2>/dev/null
     assert_output "8.1"
-    run ddev exec ls wordpress/wp-config.php
+    run ddev exec ls wordpress/wp-config.php 2>/dev/null
     assert_output "wordpress/wp-config.php"
     ddev describe -j >describe.json
     run  jq -r .raw.docroot <describe.json


### PR DESCRIPTION
## The Issue

Recent tests on HEAD have been showing this output on every single command (like all `ddev exec`) and it breaks some fragile comparisons.
> Instrumentation is opted in, but AmplitudeAPIKey is not available. This usually means you have a locally-built ddev binary or one from a PR build. It's not an error. Please report it if you're using an official release build.


## How This PR Solves The Issue

* Direct stderr to /dev/null on ddev exec, which cleans it up

## Discussion

It looks to me like `brew install --HEAD` version of ddev/ddev/ddev is showing this on all commands, but that's a bit much. It could only show on `ddev start`. I think this is a recent regression in ddev or homebrew.