### PR TITLE
tests: composerversion test failed due to composer version output changing

### DIFF
--- a/tests/composerversion.bats
+++ b/tests/composerversion.bats
@@ -28,7 +28,7 @@ teardown() {
         base=$(basename $t)
         expectedComposerVersion=${base#*_}
         echo "# base=${base} expectedComposerVersion=${expectedComposerVersion}" >&3
-        run ddev exec "composer --version | awk '{print \$3}'" 2>/dev/null
+        run ddev exec "composer --version 2>&1 | awk '/^Composer/ {print \$3}'" 2>/dev/null
 
         # If version has a caret, then we just want the first number
         # Otherwise we use the explicit value provided


### PR DESCRIPTION

## The Issue

In composer version 2.7.2 they changed the output of composer --version; broke test

## How This PR Solves The Issue

Improve the test to handle it.

