### PR TITLE
Remove obsolete platform self:update, fixes #122

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -294,7 +294,6 @@ post_install_actions:
   
   hooks:
     post-start:
-    - exec: platform self:update -qy --no-major || true
     - exec: mkdir -p ${PLATFORM_CACHE_DIR} || true
     - exec: '[ ! -z "${PLATFORMSH_CLI_TOKEN:-}" ] && (platform ssh-cert:load  -y || true)'
   {{ if eq .platformapp.build.flavor "composer" }}


### PR DESCRIPTION
## The Issue

* #122 

## How This PR Solves The Issue

`self:update` was removed in the go version of `platform` cli.

Don't do it any more.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

