### PR TITLE
fix: Use explicit paths in install.yaml instead of assuming pwd

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -71,6 +71,7 @@ pre_install_actions:
       read platform_project
       echo "platform_project = '${platform_project}'"
       # Put the platform_project in to the project's web environment
+      cd ${DDEV_APPROOT}
       ddev config --web-environment-add PLATFORM_PROJECT=${platform_project}
       echo "PLATFORM_PROJECT set to ${platform_project}"
     fi
@@ -83,6 +84,7 @@ pre_install_actions:
     #ddev-description:Setting PLATFORM_APPLICATION_NAME
     if !( {{ contains "PLATFORM_APPLICATION_NAME" (list .DdevProjectConfig.web_environment | toString) }} ); then
       # Put the platform_project in to the project's web environment
+      cd ${DDEV_APPROOT}
       ddev config --web-environment-add PLATFORM_APPLICATION_NAME={{ .platformapp.name }}
     fi
 

--- a/install.yaml
+++ b/install.yaml
@@ -108,7 +108,7 @@ post_install_actions:
 - |
   #ddev-nodisplay
   #ddev-description:Support composer and python3 dependencies
-  cat <<-ENDDOCKERFILE >> web-build/Dockerfile.platformsh
+  cat <<-ENDDOCKERFILE >> ${DDEV_APPROOT}/.ddev/web-build/Dockerfile.platformsh
   {{ if .platformapp.dependencies.php }}{{ range $pkg, $version := .platformapp.dependencies.php }}{{ if ne $pkg "composer/composer" }}
   ENV COMPOSER_HOME=/usr/local/composer
   RUN echo  "export PATH=\${PATH}:\${COMPOSER_HOME}/vendor/bin" >/etc/bashrc/composerpath.bashrc
@@ -133,17 +133,17 @@ post_install_actions:
       # The double-run here is awkward, but I didn't figure out how to do it with two '-e'
       docker run -i --rm ddev/ddev-utilities perl -p -e "s!APP_URL=.*!APP_URL=${DDEV_PRIMARY_URL}!g" <.env.example | docker run -i --rm ddev/ddev-utilities perl -p -e 's!DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)!DB_\1=db!g'   >.env
       ;;
-    drupal9)
-      mkdir -p .drush
+    drupal*)
+      mkdir -p ${DDEV_APPROOT}/.drush
       ;;
   esac
 
 - |
   #ddev-nodisplay
   #ddev-description: Install .environment file into web-entrypoint.d if needed
-  if [ -f ../.environment ]; then
-    mkdir -p web-entrypoint.d
-    cp ../.environment web-entrypoint.d/environment.sh
+  if [ -f ${DDEV_APPROOT}/.environment ]; then
+    mkdir -p ${DDEV_APPROOT}/.ddev/web-entrypoint.d
+    cp ${DDEV_APPROOT}/.environment ${DDEV_APPROOT}/.ddev/web-entrypoint.d/environment.sh
   fi
 
 # Write a config.platformsh.yaml based on calculated values, php version, database, docroot
@@ -177,7 +177,7 @@ post_install_actions:
   {{ $id = $v.id }}
   {{ end }}
 
-  r=$(./platformsh/generate_route.sh "${DDEV_PRIMARY_URL}/"  '{{ $id }}' '{{ $v.production_url }}' '{{ $v.upstream }}' '{{ $v.type }}' '{{ $v.original_url }}' | ${BASE64_ENCODE})
+  r=$(${DDEV_APPROOT}/.ddev/platformsh/generate_route.sh "${DDEV_PRIMARY_URL}/"  '{{ $id }}' '{{ $v.production_url }}' '{{ $v.upstream }}' '{{ $v.type }}' '{{ $v.original_url }}' | ${BASE64_ENCODE})
   #echo "r=$r"
   routes+=(${r})
   {{ end }}
@@ -219,13 +219,13 @@ post_install_actions:
           printf "\n\nThere is an existing database in this project that doesn\'t match the upstream database type.\n Please use 'ddev delete' to delete the existing database and retry, or try 'ddev debug migrate-database {{ $dbtype }}' to migrate the database.\n" >&2
           false
         fi
-        # echo ./platformsh/generate_db_relationship.sh '{{ $relationship_name }}' '{{ $dbtype }}' '{{ $relationship_name }}' 
-        relationships+=($(./platformsh/generate_db_relationship.sh '{{ $relationship_name }}' '{{ $dbtype }}' '{{ $relationship_name }}' | ${BASE64_ENCODE}))
+        # echo ${DDEV_APPROOT}/.ddev/platformsh/generate_db_relationship.sh '{{ $relationship_name }}' '{{ $dbtype }}' '{{ $relationship_name }}' 
+        relationships+=($(${DDEV_APPROOT}/.ddev/platformsh/generate_db_relationship.sh '{{ $relationship_name }}' '{{ $dbtype }}' '{{ $relationship_name }}' | ${BASE64_ENCODE}))
         #printf "relationships length after db=${#relationships[@]}\nrelationships value=$(echo $relationships | ${BASE64_DECODE})"
       {{ end }}
     {{ else if hasKey $supported_services $service_def.type }}
       {{/* Other services */}}
-      relationships+=($(./platformsh/generate_{{ $service_def.type }}_relationship.sh '{{ $relationship_name }}' | ${BASE64_ENCODE}))
+      relationships+=($(${DDEV_APPROOT/.ddev/platformsh/generate_{{ $service_def.type }}_relationship.sh '{{ $relationship_name }}' | ${BASE64_ENCODE}))
       {{ $service_addon := get $supported_services $service_def.type }}
       {{ if $service_addon }}
         echo "Running 'ddev get {{ $service_addon }}'"
@@ -240,13 +240,13 @@ post_install_actions:
   
   {{ $phpversion := trimPrefix "php:" .platformapp.type }}
 
-  if [ -f config.platformsh.yaml ] && ! grep '#ddev-generated' config.platformsh.yaml; then
+  if [ -f ${DDEV_APPROOT}/.ddev/config.platformsh.yaml ] && ! grep '#ddev-generated' ${DDEV_APPROOT}/.ddev/config.platformsh.yaml; then
     echo "Existing config.platformsh.yaml does not have #ddev-generated, so can't be updated"
     exit 2
   fi
-  rm -f .config.platformsh.yaml
+  rm -f ${DDEV_APPROOT}/.ddev/config.platformsh.yaml
   
-  cat <<-EOF >config.platformsh.yaml
+  cat <<-EOF >${DDEV_APPROOT}/.ddev/config.platformsh.yaml
   # #ddev-generated
   # Generated configuration based on platform.sh project configuration
   disable_settings_management: true
@@ -290,7 +290,7 @@ post_install_actions:
   
   # Because "ENDOFHOOKS" is quoted here, no variable expansion occurs
   # so everything is left alone.
-  cat <<-"ENDOFHOOKS" >>config.platformsh.yaml
+  cat <<-"ENDOFHOOKS" >>${DDEV_APPROOT}/.ddev/config.platformsh.yaml
   
   hooks:
     post-start:
@@ -328,7 +328,7 @@ post_install_actions:
   ENDOFHOOKS
 
 yaml_read_files:
-  platformapp: .platform.app.yaml
-  services: .platform/services.yaml
-  routes: .platform/routes.yaml
+  platformapp: ${DDEV_APPROOT}/.platform.app.yaml
+  services: ${DDEV_APPROOT}/.platform/services.yaml
+  routes: ${DDEV_APPROOT}/.platform/routes.yaml
 

--- a/install.yaml
+++ b/install.yaml
@@ -225,7 +225,7 @@ post_install_actions:
       {{ end }}
     {{ else if hasKey $supported_services $service_def.type }}
       {{/* Other services */}}
-      relationships+=($(${DDEV_APPROOT/.ddev/platformsh/generate_{{ $service_def.type }}_relationship.sh '{{ $relationship_name }}' | ${BASE64_ENCODE}))
+      relationships+=($(${DDEV_APPROOT}/.ddev/platformsh/generate_{{ $service_def.type }}_relationship.sh '{{ $relationship_name }}' | ${BASE64_ENCODE}))
       {{ $service_addon := get $supported_services $service_def.type }}
       {{ if $service_addon }}
         echo "Running 'ddev get {{ $service_addon }}'"
@@ -328,7 +328,7 @@ post_install_actions:
   ENDOFHOOKS
 
 yaml_read_files:
-  platformapp: ${DDEV_APPROOT}/.platform.app.yaml
-  services: ${DDEV_APPROOT}/.platform/services.yaml
-  routes: ${DDEV_APPROOT}/.platform/routes.yaml
+  platformapp: .platform.app.yaml
+  services: .platform/services.yaml
+  routes: .platform/routes.yaml
 

--- a/tests/per_test.sh
+++ b/tests/per_test.sh
@@ -10,7 +10,7 @@ per_test_setup() {
   # If the template happens to have a .ddev directory, remove as it can break things
   rm -rf .ddev
   # Start with bogus settings so we know we got the right stuff when testing
-  ddev config --project-name=${PROJNAME} --php-version=5.6 --database=mariadb:10.1 --docroot=x --create-docroot --project-type=php --web-environment-add=PLATFORMSH_CLI_TOKEN=notokenrightnow,PLATFORM_PROJECT=notyet,PLATFORM_ENVIRONMENT=notyet
+  ddev config --project-name=${PROJNAME} --php-version=5.6 --database=mariadb:10.1 --docroot=x --project-type=php --web-environment-add=PLATFORMSH_CLI_TOKEN=notokenrightnow,PLATFORM_PROJECT=notyet,PLATFORM_ENVIRONMENT=notyet
   echo "# doing ddev get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${PROJECT_SOURCE}
   echo "# doing ddev restart with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3


### PR DESCRIPTION
## The Issue

The install.yaml makes many assumptions about what directory we're in in pre_install_hooks, post_install_hooks, and yaml_read_files

Except... `yaml_read_files` cannot currently be made explicit.

## How This PR Solves The Issue

Make those all explicit.

## Manual Testing Instructions

Test with 
```
ddev get https://github.com/rfay/ddev-platformsh/tarball/20240730_explicit_paths_install_yaml
```

* Normal testing (automated tests may do the job)
* Test with 
* https://github.com/ddev/ddev/pull/6447

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

