### PR TITLE
refactor: replace `ddev get` with `ddev add-on get`, add bats libraries load

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This repository is used with `ddev add-on get ddev/ddev-platformsh` to get a ric
 ## Using with a Platform.sh project
 ### Dependencies
 
-Make sure you have [DDEV v1.23.3+ installed](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/)
+Make sure you have [DDEV v1.23.3+ installed](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/)
 
 ### Install
 1. Clone your project repository (e.g. `platform get <projectid>`)
 2. `cd` into your project directory
 3. Run `ddev config` and answer the questions as appropriate
-4. Run `ddev add-on get ddev/ddev-platformsh` (or `ddev get ddev/ddev-platformsh` if your DDEV version is older than v1.23.5) and answer the questions as appropriate
+4. Run `ddev add-on get ddev/ddev-platformsh` and answer the questions as appropriate
 5. Run `ddev start`
 6. (Optional) Run `ddev pull platform` to retrieve a copy of the database and contents from the project's file mounts from the environment you entered in step #5. (If you only want to retrieve the database (skipping the file mounts), add the `--skip-files` flag to the `ddev pull platform` command.)
 
@@ -28,7 +28,7 @@ If you change your `.platform.app.yaml` or something in your `.platform` directo
 ## Notes
 
 * If your local project has a different database type than the upstream (Platform.sh) database, it will conflict, so please back up your database with `ddev export-db` and `ddev delete` before starting the project with new config based on upstream.
-* Your experience is super-important: Please let us know about how it went for you in any of the [DDEV support venues](https://ddev.readthedocs.io/en/latest/users/support/)
+* Your experience is super-important: Please let us know about how it went for you in any of the [DDEV support venues](https://ddev.readthedocs.io/en/stable/users/support/)
 
 ## What does it do right now?
 
@@ -47,7 +47,7 @@ If you change your `.platform.app.yaml` or something in your `.platform` directo
     * Redis-persistent
     * Memcached
     * ElasticSearch
-* Provides the following [Platform.sh-provided environmental variables](https://docs.platform.sh/development/variables/use-variables.html#use-platformsh-provided-variables): 
+* Provides the following [Platform.sh-provided environmental variables](https://docs.platform.sh/development/variables/use-variables.html#use-platformsh-provided-variables):
   * PLATFORM_APP_DIR
   * PLATFORM_APPLICATION_NAME
   * PLATFORM_CACHE_DIR

--- a/commands/web/platform
+++ b/commands/web/platform
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Description: Run platform.sh CLI inside the web container

--- a/tests/composerversion.bats
+++ b/tests/composerversion.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
@@ -22,8 +22,8 @@ teardown() {
         ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
         echo "# doing ddev config --project-name=${PROJNAME}" >&3
         ddev config --project-name=${PROJNAME} >/dev/null
-        echo "# doing ddev get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-        printf "x\nx\nx\n" | ddev get $source
+        echo "# doing ddev add-on get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+        printf "x\nx\nx\n" | ddev add-on get $source
         ddev start -y >/dev/null
         base=$(basename $t)
         expectedComposerVersion=${base#*_}

--- a/tests/drupal10.bats
+++ b/tests/drupal10.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
 }

--- a/tests/drupal9.bats
+++ b/tests/drupal9.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
 }

--- a/tests/laravel.bats
+++ b/tests/laravel.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
   load per_test.sh

--- a/tests/mismatched-database.bats
+++ b/tests/mismatched-database.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
@@ -21,8 +21,8 @@ teardown() {
     echo "# doing ddev config --project-name=${PROJNAME}" >&3
     ddev config --project-name=${PROJNAME} --database=mariadb:10.2 >/dev/null
     ddev start -y >/dev/null
-    echo "# doing ddev get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-    printf 'x\nx\nx\n' | (ddev get $source 2>&1 || true) | grep "There is an existing database in this project"
+    echo "# doing ddev add-on get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+    printf 'x\nx\nx\n' | (ddev add-on get $source 2>&1 || true) | grep "There is an existing database in this project"
     popd >/dev/null
 
     per_test_teardown

--- a/tests/mysql.bats
+++ b/tests/mysql.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
@@ -21,8 +21,8 @@ teardown() {
     ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
     echo "# doing ddev config --project-name=${PROJNAME}" >&3
     ddev config --project-name=${PROJNAME} >/dev/null
-    echo "# doing ddev get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-    printf "x\nx\nx\n" | ddev get $source
+    echo "# doing ddev add-on get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+    printf "x\nx\nx\n" | ddev add-on get $source
     ddev start -y >/dev/null
     DDEV_DEBUG="" ddev describe -j >/tmp/describe.json
     run ddev exec -s db 'echo ${DDEV_DATABASE}' >/dev/null

--- a/tests/oddrelationships.bats
+++ b/tests/oddrelationships.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
@@ -20,8 +20,8 @@ teardown() {
     ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
     echo "# doing ddev config --project-name=${PROJNAME}" >&3
     ddev config --project-name=${PROJNAME} >/dev/null
-    echo "# doing ddev get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-    printf "x\nx\nx\n" | ddev get $source
+    echo "# doing ddev add-on get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+    printf "x\nx\nx\n" | ddev add-on get $source
     ddev start -y >/dev/null
     DDEV_DEBUG="" ddev describe -j >/tmp/describe.json
     run ddev exec -s db 'echo ${DDEV_DATABASE}' >/dev/null

--- a/tests/oracle-mysql.bats
+++ b/tests/oracle-mysql.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
@@ -20,8 +20,8 @@ teardown() {
     ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
     echo "# doing ddev config --project-name=${PROJNAME}" >&3
     ddev config --project-name=${PROJNAME} >/dev/null
-    echo "# doing ddev get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-    printf "x\nx\nx\n" | ddev get $source
+    echo "# doing ddev add-on get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+    printf "x\nx\nx\n" | ddev add-on get $source
     ddev start -y >/dev/null
     DDEV_DEBUG="" ddev describe -j >/tmp/describe.json
     run ddev exec -s db 'echo ${DDEV_DATABASE}' >/dev/null

--- a/tests/per_test.sh
+++ b/tests/per_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 per_test_setup() {
   set -e -o pipefail
@@ -11,8 +11,8 @@ per_test_setup() {
   rm -rf .ddev
   # Start with bogus settings so we know we got the right stuff when testing
   ddev config --project-name=${PROJNAME} --php-version=5.6 --database=mariadb:10.1 --docroot=x --create-docroot --project-type=php --web-environment-add=PLATFORMSH_CLI_TOKEN=notokenrightnow,PLATFORM_PROJECT=notyet,PLATFORM_ENVIRONMENT=notyet
-  echo "# doing ddev get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${PROJECT_SOURCE}
+  echo "# doing ddev add-on get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${PROJECT_SOURCE}
   echo "# doing ddev restart with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev restart >/dev/null
   if [ -f ${PROJECT_SOURCE}/tests/testdata/${template}/db.sql.gz ]; then

--- a/tests/php.bats
+++ b/tests/php.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
   load per_test.sh

--- a/tests/postgresql.bats
+++ b/tests/postgresql.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
@@ -20,8 +20,8 @@ teardown() {
     ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
     echo "# doing ddev config --project-name=${PROJNAME}" >&3
     ddev config --project-name=${PROJNAME} >/dev/null
-    echo "# doing ddev get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-    printf "x\nx\nx\n" | ddev get $source
+    echo "# doing ddev add-on get $source with template ${template} PROJNAME=${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+    printf "x\nx\nx\n" | ddev add-on get $source
     ddev start -y >/dev/null
     DDEV_DEBUG="" ddev describe -j >/tmp/describe.json
     run ddev exec -s db 'echo ${DDEV_DATABASE}' >/dev/null

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,12 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Bats is a testing framework for Bash
+# Documentation https://bats-core.readthedocs.io/en/stable/
+# Bats libraries documentation https://github.com/ztombol/bats-docs
+
+# For local tests, install bats-core, bats-assert, bats-file, bats-support
+# And run this in the add-on root directory:
+#   bats ./tests/test.bats
+# To exclude release tests:
+#   bats ./tests/test.bats --filter-tags '!release'
+# For debugging:
+#   bats ./tests/test.bats --show-output-of-passing-tests --verbose-run --print-output-on-failure
 
 bats_require_minimum_version 1.8.0
 set -eu -o pipefail
-export PROJECT_SOURCE="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
+export PROJECT_SOURCE="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
 export TESTDIR=~/tmp/test-platformsh
 export PROJNAME=test-platformsh
-export DDEV_NON_INTERACTIVE=true
-brew_prefix=$(brew --prefix)
+export DDEV_NONINTERACTIVE=true
+export DDEV_NO_INSTRUMENTATION=true
 docker volume rm $PROJNAME-mariadb 2>/dev/null || true
-load "${brew_prefix}/lib/bats-support/load.bash"
-load "${brew_prefix}/lib/bats-assert/load.bash"
+TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+export BATS_LIB_PATH="${BATS_LIB_PATH}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats"
+bats_load_library bats-assert
+bats_load_library bats-file
+bats_load_library bats-support

--- a/tests/teardown.sh
+++ b/tests/teardown.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}

--- a/tests/wordpress-bedrock.bats
+++ b/tests/wordpress-bedrock.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
 }

--- a/tests/wordpress-composer.bats
+++ b/tests/wordpress-composer.bats
@@ -1,6 +1,6 @@
-# Requires bats-assert and bats-support
-# brew tap kaos/shell &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
+#!/usr/bin/env bats
+
+# see setup.sh for instructions
 setup() {
   load setup.sh
 }


### PR DESCRIPTION
## The Issue

Upstream `ddev-addon-template` has some changes.

## How This PR Solves The Issue

- Replaces `ddev get` with `ddev add-on get`
- Adds bats libraries properly (so it works for macOS and Linux)
- Replaces `#!/bin/bash bash` with `#!/usr/bin/env bash`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
