### PR TITLE
refactor: use v1.24.3 constraint, update readme, concurrency in test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,11 @@ on:
         required: false
         default: false
 
-# Required permissions for keep-alive, used by ddev/github-action-add-on-test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
   actions: write
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
-[![tests](https://github.com/ddev/ddev-platformsh/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-platformsh/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
+[![tests](https://github.com/ddev/ddev-platformsh/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-platformsh/actions/workflows/tests.yml?query=branch%3Amain)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-platformsh)](https://github.com/ddev/ddev-platformsh/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-platformsh)](https://github.com/ddev/ddev-platformsh/releases/latest)
 
-## What is ddev-platformsh?
+# DDEV Platform.sh
 
-This repository is used with `ddev add-on get ddev/ddev-platformsh` to get a rich integration between your checked-out Platform.sh project and [DDEV](https://github.com/ddev/ddev).
+## Overview
+
+[Platform.sh](https://platform.sh/) is a unified, secure, enterprise-grade platform for building, running and scaling web applications.
+
+This repository is used with `ddev add-on get ddev/ddev-platformsh` to get a rich integration between your checked-out Platform.sh project and [DDEV](https://ddev.com).
 
 ## Using with a Platform.sh project
+
 ### Dependencies
 
-Make sure you have [DDEV v1.23.3+ installed](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/)
+Make sure you have [DDEV v1.24.3+ installed](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/)
 
 ### Install
 1. Clone your project repository (e.g. `platform get <projectid>`)
@@ -78,5 +86,7 @@ These Platform.sh templates are included in the automated tests that run nightly
 - [x] Automatically figure out the name and other information of the upstream project
 - [x] Automatically configure the .ddev/providers/platform so you can immediately do a `ddev pull platform` with no configuration effort.
 - [ ] Let us know what's important to you!
+
+## Credits
 
 **Maintained by [@rfay](https://github.com/rfay)**

--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ If you change your `.platform.app.yaml` or something in your `.platform` directo
 * Works with many projects of type `php`, for example, `php:8.2` or `php:8.3`. It does not work with non-php projects.
 * Takes your checked-out Platform.sh project and configures DDEV based on that information.
     * PHP and Database version
-    * hooks are converted to DDEV post-start hooks
+    * Hooks are converted to DDEV post-start hooks
     * A working `ddev pull platform` integration with all mounts is created.
     * Exposes specific `$PLATFORM_` variables (e.g., `$PLATFORM_RELATIONSHIPS`, `$PLATFORM_ROUTES`)
 * Supports the following services:
     * Databases
       * MariaDB
       * Oracle MySQL
-      * Postgresql
+      * PostgreSQL
     * Redis
     * Redis-persistent
     * Memcached
-    * ElasticSearch
+    * Elasticsearch
 * Provides the following [Platform.sh-provided environmental variables](https://docs.platform.sh/development/variables/use-variables.html#use-platformsh-provided-variables):
   * PLATFORM_APP_DIR
   * PLATFORM_APPLICATION_NAME

--- a/install.yaml
+++ b/install.yaml
@@ -1,6 +1,6 @@
 name: ddev-platformsh
 
-ddev_version_constraint: '>= v1.23.3'
+ddev_version_constraint: '>= v1.24.3'
 
 project_files:
   - web-build/Dockerfile.platformsh
@@ -322,4 +322,3 @@ yaml_read_files:
   platformapp: .platform.app.yaml
   services: .platform/services.yaml
   routes: .platform/routes.yaml
-


### PR DESCRIPTION
## The Issue

Upstream `ddev-addon-template` has some changes.

## How This PR Solves The Issue

- Uses v1.24.3 version constraint
- Adds new badges to the README.md
- Updates tests.yml concurrency

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-platformsh/tarball/20250418_stasadev_readme_and_constraint
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
