### PR TITLE
test: Update drupal11 test to use mariadb:10.11

### DIFF
--- a/tests/drupal11.bats
+++ b/tests/drupal11.bats
@@ -22,7 +22,7 @@ teardown() {
     assert_output --partial "Test of ddev-platformsh on drupal11"
 
     run ddev exec -s db 'echo ${DDEV_DATABASE}' 2>/dev/null
-    assert_output "mariadb:10.6"
+    assert_output "mariadb:10.11"
     run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'" 2>/dev/null
     assert_output "8.3"
 

--- a/tests/drupal11.bats
+++ b/tests/drupal11.bats
@@ -38,7 +38,7 @@ teardown() {
     ddev exec 'echo $PLATFORM_ROUTES | base64 -d' >routes.json 2>/dev/null
     echo "# PLATFORM_ROUTES=$(cat routes.json)" >&3
 
-    assert_equal "$(jq -r .database[0].type <relationships.json)" "mariadb:10.6"
+    assert_equal "$(jq -r .database[0].type <relationships.json)" "mariadb:10.11"
     assert_equal "$(jq -r .database[0].username <relationships.json)" "db"
     assert_equal "$(jq -r .database[0].password <relationships.json)" "db"
     assert_equal "$(jq -r .redis[0].hostname <relationships.json)" "redis"


### PR DESCRIPTION
## The Issue

The upstream template changed to use mariadb:10.11 from 10.6 in 
* https://github.com/platformsh-templates/drupal11/pull/7

## How This PR Solves The Issue

Look for 10.11 now.

